### PR TITLE
Change "powerful"

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
 							<div class="caption">
 								<div>
 									<h3>Why AutoHotkey</h3>
-									<p>Autohotkey gives you the freedom to develop powerful scripts to automate any desktop task. It's free, open-source (GNU GPLv2), and beginner-friendly. <br>Why not give it a try?</p>
+									<p>Autohotkey gives you the freedom to automate any desktop task. It's free, open-source (GNU GPLv2), and beginner-friendly. <br>Why not give it a try?</p>
 								</div>
 								<p class="group"><a href="/docs/scripts/index.htm" class="btn btn-default">LEARN MORE</a></p>
 							</div>


### PR DESCRIPTION
The word "powerful" is used in several other places on the page. I suggest finding a synonym (ex "robust"). 
Or remove that part of the sentence, as I have done in this pull request.