### PR TITLE
Remove hyphens

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@
 							<img alt="" src="assets/images/heiseonline.gif">
 							<div class="caption">
 								<div>
-									<h3>AutoHotkey sends several tools into retirement. It unites hotkey and text macros, and offers a scripting-language which is more powerful than any batch-file.</h3>
+									<h3>AutoHotkey sends several tools into retirement. It unites hotkey and text macros, and offers a scripting language which is more powerful than any batch file.</h3>
 									<p>Wolfgang Reszel, c't Magazine (translated to English)<br></p>
 								</div>
 								


### PR DESCRIPTION
Wikipedia pages for these phrases are not hyphenated:
https://en.wikipedia.org/wiki/Batch_file
https://en.wikipedia.org/wiki/Scripting_language