### PR TITLE
Increase margin between "AutoHotkey" and subtexts

### DIFF
--- a/assets/mobirise/css/style.css
+++ b/assets/mobirise/css/style.css
@@ -9,7 +9,7 @@ h3.mbr-header__text {
   font-family: "Myriad Pro", "Segoe UI", "Roboto", Arial, Helvetica, sans-serif;
   font-weight: normal;
   text-shadow: 1px 1px 60px;
-  margin-bottom: 3px;
+  margin-bottom: 20px;
 }
 /*..................................*/
 html {


### PR DESCRIPTION
This bugs me everytime I see it :sweat_smile:

I recommend increasing the margin between the "AutoHotkey" heading and the subtext a little bit to improve the look.